### PR TITLE
Remove Sha Check

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@
     </li>
     <li><a href="#roadmap">Roadmap</a></li>
     <li><a href="#contributing">Contributing</a></li>
+    <li><a href="#decision-records">Decision Records</a></li>
     <li><a href="#license">License</a></li>
   </ol>
 </details>
@@ -177,6 +178,18 @@ Don't forget to give the project a star! Thanks again!
 
 <p align="right">(<a href="#top">back to top</a>)</p>
 
+
+
+<!-- DECISION RECORDS -->
+## Decision Records
+
+**August 2022: Dropping sha check**<br/>
+While renovate bot can update digests (including sha of release assets), it cannot update digests for source code downloads that are required for ninja & vcpkg.
+Curl (used to download the archives, see install_vcpkg.sh) verifies server certificates via root CA check, which is arguably better than comparing sha to an automatically updated one, anyway.
+Therefore I decided to drop the check in order to improve maintainability of the project.
+
+
+<p align="right">(<a href="#top">back to top</a>)</p>
 
 
 <!-- LICENSE -->

--- a/renovate.json
+++ b/renovate.json
@@ -12,15 +12,6 @@
         "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\s[^=]+=(?<currentValue>.*)\\s"
       ],
       "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}"
-    },
-    {
-      "fileMatch": [
-        ".env$"
-      ],
-      "matchStrings": [
-        "# renovate: withdigest datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\s[^=]+=(?<currentValue>.*)[^_=]+_DIGEST=(?<currentDigest>.*)\\s"
-      ],
-      "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}"
     }
   ]
 }

--- a/version_vcpkg.env
+++ b/version_vcpkg.env
@@ -1,15 +1,12 @@
 
 # Find new versions here: https://github.com/ninja-build/ninja/releases
-# renovate: withdigest datasource=github-releases depName=ninja-build/ninja versioning=loose
+# renovate: datasource=github-releases depName=ninja-build/ninja versioning=loose
 NINJA_VERSION=v1.11.0
-NINJA_DIGEST=3c6ba2e66400fe3f1ae83deb4b235faf3137ec20bd5b08c29bfc368db143e4c6
 
 # Find new versions here: https://github.com/microsoft/vcpkg/releases
-# renovate: withdigest datasource=github-releases depName=microsoft/vcpkg versioning=loose
+# renovate: datasource=github-releases depName=microsoft/vcpkg versioning=loose
 VCPKG_VERSION=2022.07.25
-VCPKG_DIGEST=92313ef2c06e2748fa3a41fa7c6986a32dd33045b44ae228172aa385ce330bba
 
 # Find new cmake versions here: https://github.com/Kitware/CMake/releases
-# renovate: withdigest datasource=github-releases depName=Kitware/CMake versioning=loose
+# renovate: datasource=github-releases depName=Kitware/CMake versioning=loose
 CMAKE_VERSION=v3.24.0
-CMAKE_DIGEST=5478ac63cf3e90aacb80b5ce01777537e880392add78529dcad5f8c80cbde0fa


### PR DESCRIPTION
Improves maintainability by relying on curl's certificate verification and renovatebots updates, instead of a sha check with manually verified hash.